### PR TITLE
List only changes

### DIFF
--- a/conf/commands.json
+++ b/conf/commands.json
@@ -37,6 +37,9 @@
     "changes": {
       "desc": "Display the changes in local repositories"
     },
+    "changes-short": {
+      "desc": "Display the changes in local repositories in short form"
+    },
     "save": {
       "desc": "Update remote repositories with changes from local repositories"
     },

--- a/conf/commands.json
+++ b/conf/commands.json
@@ -38,9 +38,6 @@
     "changes": {
       "desc": "Display the changes in local repositories"
     },
-    "changes-short": {
-      "desc": "Display the changes in local repositories in short form"
-    },
     "save": {
       "desc": "Update remote repositories with changes from local repositories"
     },

--- a/conf/commands.json
+++ b/conf/commands.json
@@ -1,6 +1,7 @@
 {
   "options": [
     { "arg": "-f, --fail-fast", "desc": "Exit as soon as any command failure" },
+    { "arg": "-v, --verbose", "desc": "Print executed commands (for debugging" },
     { "arg": "-c, --config-file <configFile>", "desc": "Configuration file" },
     { "arg": "-t, --tags <tags>", "desc": "Comma-separated tags filter, to be matched against repo tags" },
     { "arg": "-r, --regex <regex>", "desc": "Regular expression filter, to be matched against repo name and URL" }

--- a/conf/scms-win32.json
+++ b/conf/scms-win32.json
@@ -3,8 +3,7 @@
     "delete": "rmdir {workspace}\\\\{name} /s /q",
     "init": "git clone {url} {workspace}\\\\{name}",
     "get": "cd {workspace}\\\\{name} && git pull --rebase",
-    "changes": "cd {workspace}\\\\{name} && git status",
-    "changes-short": "cd {workspace}\\\\{name} && git status -s && git log --branches --not --remotes --oneline",
+    "changes": "cd {workspace}\\\\{name} && git status -s && git log --branches --not --remotes --oneline",
     "save": "cd {workspace}\\\\{name} && git push origin master",
     "undo": "cd {workspace}\\\\{name} && git stash && git stash clear"
   },
@@ -13,7 +12,6 @@
     "init": "svn checkout {url} {workspace}\\\\{name}",
     "get": "cd {workspace}\\\\{name} && svn up",
     "changes": "cd {workspace}\\\\{name} && svn stat",
-    "changes-short": "cd {workspace}\\\\{name} && svn stat",
     "save": "cd {workspace}\\\\{name} && svn commit -m \"Commited by Repoman\"",
     "undo": "cd {workspace}\\\\{name}; svn revert -R ."
   }

--- a/conf/scms-win32.json
+++ b/conf/scms-win32.json
@@ -4,6 +4,7 @@
     "init": "git clone {url} {workspace}\\\\{name}",
     "get": "cd {workspace}\\\\{name} && git pull --rebase",
     "changes": "cd {workspace}\\\\{name} && git status",
+    "changes-short": "cd {workspace}\\\\{name} && git status -s && git log --branches --not --remotes --oneline",
     "save": "cd {workspace}\\\\{name} && git push origin master",
     "undo": "cd {workspace}\\\\{name} && git stash && git stash clear"
   },
@@ -12,6 +13,7 @@
     "init": "svn checkout {url} {workspace}\\\\{name}",
     "get": "cd {workspace}\\\\{name} && svn up",
     "changes": "cd {workspace}\\\\{name} && svn stat",
+    "changes-short": "cd {workspace}\\\\{name} && svn stat",
     "save": "cd {workspace}\\\\{name} && svn commit -m \"Commited by Repoman\"",
     "undo": "cd {workspace}\\\\{name}; svn revert -R ."
   }

--- a/conf/scms.json
+++ b/conf/scms.json
@@ -4,6 +4,7 @@
     "init": "git clone {url} {workspace}/{name}",
     "get": "cd {workspace}/{name}; git pull --rebase",
     "changes": "cd {workspace}/{name}; git status",
+    "changes-short": "cd {workspace}/{name}; git status -s; git log --branches --not --remotes --oneline",
     "save": "cd {workspace}/{name}; git push origin master",
     "undo": "cd {workspace}/{name}; git stash; git stash clear"
   },
@@ -12,6 +13,7 @@
     "init": "svn checkout {url} {workspace}/{name}",
     "get": "cd {workspace}/{name}; svn up",
     "changes": "cd {workspace}/{name}; svn stat",
+    "changes-short": "cd {workspace}/{name}; svn stat",
     "save": "cd {workspace}/{name}; svn commit -m \"Commited by Repoman\"",
     "undo": "cd {workspace}/{name}; svn revert -R ."
   }

--- a/conf/scms.json
+++ b/conf/scms.json
@@ -3,8 +3,7 @@
     "delete": "rm -rf {workspace}/{name}",
     "init": "git clone {url} {workspace}/{name}",
     "get": "cd {workspace}/{name}; git pull --rebase",
-    "changes": "cd {workspace}/{name}; git status",
-    "changes-short": "cd {workspace}/{name}; git status -s; git log --branches --not --remotes --oneline",
+    "changes": "cd {workspace}/{name}; git status -s; git log --branches --not --remotes --oneline",
     "save": "cd {workspace}/{name}; git push origin master",
     "undo": "cd {workspace}/{name}; git stash; git stash clear"
   },
@@ -13,7 +12,6 @@
     "init": "svn checkout {url} {workspace}/{name}",
     "get": "cd {workspace}/{name}; svn up",
     "changes": "cd {workspace}/{name}; svn stat",
-    "changes-short": "cd {workspace}/{name}; svn stat",
     "save": "cd {workspace}/{name}; svn commit -m \"Commited by Repoman\"",
     "undo": "cd {workspace}/{name}; svn revert -R ."
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -127,17 +127,16 @@ function exec() {
 
   var actions = {
     commands: {
-      config          : { action: _config },
-      'delete'        : { action: _exec },
-      init            : { action: _exec },
-      get             : { action: _exec },
-      changes         : { action: _exec },
-      'changes-short' : { action: _exec },
-      save            : { action: _exec },
-      undo            : { action: _exec },
-      exec            : { action: _exec },
-      list            : { action: _list },
-      clean           : { action: _clean }
+      config  : { action: _config },
+      'delete': { action: _exec },
+      init    : { action: _exec },
+      get     : { action: _exec },
+      changes : { action: _exec },
+      save    : { action: _exec },
+      undo    : { action: _exec },
+      exec    : { action: _exec },
+      list    : { action: _list },
+      clean   : { action: _clean }
     }
   };
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -126,16 +126,17 @@ function exec() {
 
   var actions = {
     commands: {
-      config  : { action: _config },
-      'delete': { action: _exec },
-      init    : { action: _exec },
-      get     : { action: _exec },
-      changes : { action: _exec },
-      save    : { action: _exec },
-      undo    : { action: _exec },
-      exec    : { action: _exec },
-      list    : { action: _list },
-      clean   : { action: _clean }
+      config          : { action: _config },
+      'delete'        : { action: _exec },
+      init            : { action: _exec },
+      get             : { action: _exec },
+      changes         : { action: _exec },
+      'changes-short' : { action: _exec },
+      save            : { action: _exec },
+      undo            : { action: _exec },
+      exec            : { action: _exec },
+      list            : { action: _list },
+      clean           : { action: _clean }
     }
   };
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -49,6 +49,7 @@ function _exec(command, args) {
   }
 
   opts.failFast = args.parent.failFast;
+  opts.verbose = args.parent.verbose;
   opts.regex    = args.parent.regex;
   if (args.parent.tags) {
     opts.tags = args.parent.tags.split(',');

--- a/lib/repoman.js
+++ b/lib/repoman.js
@@ -115,7 +115,7 @@ Repoman.prototype.exec = function (command, opts, cb) {
         console.log('\n+ %s', name);
         jazz.compile(_command).process(params, function (text) {
           if (opts.verbose) {
-            console.log('> %s', text.replace(/^cd.+; /, ''));
+            console.log('> %s', text.replace(/^cd.+?; /, ''));
           }
           bag.exec(text, !opts.failFast, cb);
         });

--- a/lib/repoman.js
+++ b/lib/repoman.js
@@ -98,6 +98,7 @@ Repoman.prototype.exec = function (command, opts, cb) {
   opts = opts || {};
 
   opts.failFast = opts.failFast || false;
+  opts.verbose = opts.verbose || false;
 
   var dir   = process.cwd();
   var tasks = [];
@@ -113,7 +114,9 @@ Repoman.prototype.exec = function (command, opts, cb) {
       tasks.push(function (cb) {
         console.log('\n+ %s', name);
         jazz.compile(_command).process(params, function (text) {
-          console.log('> %s', text.replace(/^cd.+; /, ''));
+          if (opts.verbose) {
+            console.log('> %s', text.replace(/^cd.+; /, ''));
+          }
           bag.exec(text, !opts.failFast, cb);
         });
       });

--- a/test-integration/success-config-file.yml
+++ b/test-integration/success-config-file.yml
@@ -22,7 +22,7 @@
   output: 'Current branch master is up to date.'
 
 - description: Command exec should execute same command on all repositories
-  command: '{repoman} exec "touch somefile"'
+  command: '{repoman} exec "touch somefile" --verbose'
   exitcode: 0
   output: 'touch somefile'
 

--- a/test-integration/success.yml
+++ b/test-integration/success.yml
@@ -26,7 +26,7 @@
   output: 'Current branch master is up to date.'
 
 - description: Command exec should execute same command on all repositories
-  command: '{repoman} exec "touch somefile"'
+  command: '{repoman} exec "touch somefile" --verbose'
   exitcode: 0
   output: 'touch somefile'
 
@@ -41,11 +41,11 @@
   output: 'No local changes to save'
 
 - description: Command exec should execute nothing when tags is specified and there is no matching repo
-  command: '{repoman} --tags inexistingtag exec "touch somefile"'
+  command: '{repoman} --tags inexistingtag exec "touch somefile" --verbose'
   exitcode: 0
   output: ''
 
 - description: Command exec should execute nothing when regex is specified and there is no matching repo
-  command: '{repoman} --regex .*inexistingrepo.* exec "touch somefile"'
+  command: '{repoman} --regex .*inexistingrepo.* exec "touch somefile" --verbose'
   exitcode: 0
   output: ''

--- a/test/repoman.js
+++ b/test/repoman.js
@@ -135,7 +135,7 @@ buster.testCase('repoman - exec', {
       cb(null, command);
     });
     var repoman = new Repoman(this.repos, this.scms);
-    repoman.exec('init', {}, function cb(err, results) {
+    repoman.exec('init', { verbose: true }, function cb(err, results) {
       assert.equals(results[0], 'git clone http://git-wip-us.apache.org/repos/asf/couchdb.git /somedir/couchdb');
       assert.equals(results[1], 'svn checkout http://svn.apache.org/repos/asf/httpd/httpd/trunk/ /somedir/httpd');
       done();        
@@ -143,15 +143,15 @@ buster.testCase('repoman - exec', {
   },
   'should execute command as-is on each repository when command is unsupported': function (done) {
     this.mockConsole.expects('log').once().withExactArgs('\n+ %s', 'couchdb');
-    this.mockConsole.expects('log').once().withExactArgs('> %s', 'echo "Created /somedir/couchdb/.gitignore file";');
+    this.mockConsole.expects('log').once().withExactArgs('> %s', 'touch .gitignore; echo "Created /somedir/couchdb/.gitignore file";');
     this.mockConsole.expects('log').once().withExactArgs('\n+ %s', 'httpd');
-    this.mockConsole.expects('log').once().withExactArgs('> %s', 'echo "Created /somedir/httpd/.gitignore file";');
+    this.mockConsole.expects('log').once().withExactArgs('> %s', 'touch .gitignore; echo "Created /somedir/httpd/.gitignore file";');
     this.stub(bag, 'exec', function (command, fallthrough, cb) {
       assert.isTrue(fallthrough);
       cb(null, command);
     });
     var repoman = new Repoman(this.repos, this.scms);
-    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', undefined, function cb(err, results) {
+    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', { verbose: true }, function cb(err, results) {
       assert.equals(results.length, 2);
       assert.equals(results[0], 'cd /somedir/couchdb; touch .gitignore; echo "Created /somedir/couchdb/.gitignore file";');
       assert.equals(results[1], 'cd /somedir/httpd; touch .gitignore; echo "Created /somedir/httpd/.gitignore file";');
@@ -160,13 +160,13 @@ buster.testCase('repoman - exec', {
   },
   'should execute command as-is on matching repository when tag is provided': function (done) {
     this.mockConsole.expects('log').once().withExactArgs('\n+ %s', 'couchdb');
-    this.mockConsole.expects('log').once().withExactArgs('> %s', 'echo "Created /somedir/couchdb/.gitignore file";');
+    this.mockConsole.expects('log').once().withExactArgs('> %s', 'touch .gitignore; echo "Created /somedir/couchdb/.gitignore file";');
     this.stub(bag, 'exec', function (command, fallthrough, cb) {
       assert.isTrue(fallthrough);
       cb(null, command);
     });
     var repoman = new Repoman(this.repos, this.scms);
-    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', { tags: ['database', 'someothertag'] }, function cb(err, results) {
+    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', { tags: ['database', 'someothertag'], verbose: true }, function cb(err, results) {
       assert.equals(results.length, 1);
       assert.equals(results[0], 'cd /somedir/couchdb; touch .gitignore; echo "Created /somedir/couchdb/.gitignore file";');
       done();
@@ -174,13 +174,13 @@ buster.testCase('repoman - exec', {
   },
   'should execute command as-is on matching repository when regex is provided': function (done) {
     this.mockConsole.expects('log').once().withExactArgs('\n+ %s', 'couchdb');
-    this.mockConsole.expects('log').once().withExactArgs('> %s', 'echo "Created /somedir/couchdb/.gitignore file";');
+    this.mockConsole.expects('log').once().withExactArgs('> %s', 'touch .gitignore; echo "Created /somedir/couchdb/.gitignore file";');
     this.stub(bag, 'exec', function (command, fallthrough, cb) {
       assert.isTrue(fallthrough);
       cb(null, command);
     });
     var repoman = new Repoman(this.repos, this.scms);
-    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', { regex: '.*couchdb.*' }, function cb(err, results) {
+    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', { regex: '.*couchdb.*', verbose: true }, function cb(err, results) {
       assert.equals(results.length, 1);
       assert.equals(results[0], 'cd /somedir/couchdb; touch .gitignore; echo "Created /somedir/couchdb/.gitignore file";');
       done();
@@ -192,7 +192,7 @@ buster.testCase('repoman - exec', {
       cb(null, command);
     });
     var repoman = new Repoman(this.repos, this.scms);
-    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', { regex: 'blah', tags: ['inexistingtag1', 'inexistingtag2'] }, function cb(err, results) {
+    repoman.exec('touch .gitignore; echo "Created {workspace}/{name}/.gitignore file";', { regex: 'blah', tags: ['inexistingtag1', 'inexistingtag2'], verbose: true }, function cb(err, results) {
       assert.equals(results.length, 0);
       done();
     });


### PR DESCRIPTION
Update: I removed the new command `changes-short` that had been introduced with this PR earlier and just changed the git command for `changes`. I also fixed all tests (unit and integeration).

TL;DR: This PR makes the output for `repoman changes` much shorter. See the examples below for comparison.

----

As discussed in #16, I'd like to get a terser list of local changes.

In this PR, I changed the git command for `repoman changes` to
```
git status -s && git log --branches --not --remotes --oneline
```
(the git log part obviously following you're clever suggestion from #16)

This makes it quite a bit terser already.

I also would like to get rid of echoing the executed commands to make the output even shorter, they have no benefit for me in day-to-day use. From your comments at #8 I understand this is more for debugging. So I went ahead and added a `verbose` option. I was feeling bold and made it default to `false`, so executed commands are only echoed if you explicitly specify `--verbose`, otherwise they are omitted.

One more minor thing: The regex for printing multiple commands ate everything except the last command, I fixed that.

What do you think?

----

For an example, here is the output of `repoman changes` for my current project, without my changes:

```
+ acceptance-tests-common
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ acceptance-tests-dairynet-dataprovider
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ acceptance-tests-dairynet-ui
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ acceptance-tests-gealibs
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ acceptance-tests-gealibs-dataprovider
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ bin
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ box-project-package
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-angular
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-backend
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-dataprovider
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-dp-import
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-fn-liquibase-addon
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-frontend
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   src/main/webapp/modules.json

no changes added to commit (use "git add" and/or "git commit -a")
[39m
+ dairynet-milking
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-presentation-layer
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-project-pom
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dairynet-setup
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dev-dairynet-box-setup
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dev-dairynet-time-machine
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dev-deployment
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ dev-documents
> git status
[32mOn branch master
Your branch is ahead of 'origin/master' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working directory clean
[39m
+ dev-tools
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ gea-automation-dataprovider
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ gea-automation-domain
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ gea-automation-war
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ generator-model
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ generator-templates
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
+ qview-frontend
> git status
[32mOn branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working directory clean
[39m
```

----

Oh my gosh, that's a lot of output to process. I find it really hard to see at a glance if there is anything that still needs to be committed or pushed.

Here is the output of `repoman changes` after this changes:

----

```
+ acceptance-tests-common

+ acceptance-tests-dairynet-dataprovider

+ acceptance-tests-dairynet-ui

+ acceptance-tests-gealibs

+ acceptance-tests-gealibs-dataprovider

+ bin

+ box-project-package

+ dairynet-angular

+ dairynet-backend

+ dairynet-dataprovider

+ dairynet-dp-import

+ dairynet-fn-liquibase-addon

+ dairynet-frontend
[32m M src/main/webapp/modules.json
[39m
+ dairynet-milking

+ dairynet-presentation-layer

+ dairynet-project-pom

+ dairynet-setup

+ dev-dairynet-box-setup

+ dev-dairynet-time-machine

+ dev-deployment

+ dev-documents
[32m M .gitignore
[39m[32m30b6847 .
[39m
+ dev-tools

+ gea-automation-dataprovider

+ gea-automation-domain

+ gea-automation-war

+ generator-model

+ generator-templates

+ qview-frontend
```
Ah, much better. It only lists the project names and changes.

In an ideal world, I would like to have this output:

```
+ dairynet-frontend
[32m M src/main/webapp/modules.json
[39m
+ dev-documents
[32m M .gitignore
[39m[32m30b6847 .
[39m
```

That is, only list project with changes and omit projects without changes entirely. But this would probably require more changes in repoman logic and the current output is good enough.