### PR TITLE
config option to allow ssh

### DIFF
--- a/conf/commands.json
+++ b/conf/commands.json
@@ -15,7 +15,8 @@
         { "arg": "--github-user <githubUser>", "desc": "Comma-separated GitHub usernames" },
         { "arg": "--github-org <githubOrg>", "desc": "Comma-separated GitHub organisations" },
         { "arg": "--github-auth-user <githubAuthUser>", "desc": "GitHub authentication username" },
-        { "arg": "--github-auth-pass <githubAuthPass>", "desc": "GitHub authentication password" },
+        { "arg": "--github-auth-pass <githubAuthPass>", "desc": "GitHub authentication password" },        
+        { "arg": "--github-use-ssh", "desc": "Use the ssh url from Github instead of the standard clone url where possible" },        
         { "arg": "--gitorious-url <gitoriousUrl>", "desc": "Gitorious URL" },
         { "arg": "--gitorious-project <gitoriousProject>", "desc": "Comma-separated Gitorious projects" },
         { "arg": "--local", "desc": "Create configuration file from local repositories" }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,7 +20,8 @@ function _config(args) {
       user    : args.githubUser,
       org     : args.githubOrg,
       authUser: args.githubAuthUser,
-      authPass: args.githubAuthPass
+      authPass: args.githubAuthPass,
+      useSsh : args.githubUseSsh   
     };
 
   } else if (args.gitoriousUrl || args.gitoriousProject) {

--- a/lib/generator/github.js
+++ b/lib/generator/github.js
@@ -12,7 +12,7 @@ var GithubAuth = require('../auth/github');
  * @param {String} user: GitHub username
  * @param {String} pass: GitHub password
  */
-function GitHub(ready, user, pass) {
+function GitHub(ready, user, pass, useSsh) {
 
   var opts = {
     version: '3.0.0',
@@ -29,7 +29,8 @@ function GitHub(ready, user, pass) {
   }
 
   this.gh = new github(opts);
-
+  this.useSsh = useSsh;
+  
   var self = this;
   if (user && pass) {
     // if credentials are provided, use those to authenticate
@@ -113,7 +114,8 @@ GitHub.prototype.generate = function (users, orgs, cb) {
     if (!err) {
       results.forEach(function (result) { // each task (user and org)
         result.forEach(function (repo) { // each repo in each task's result
-          config[repo.name] = { url: repo.clone_url };
+          var url = self.useSsh && repo.ssh_url || repo.clone_url;
+          config[repo.name] = { url: url };
         });
       });
     }

--- a/lib/repoman.js
+++ b/lib/repoman.js
@@ -59,7 +59,7 @@ Repoman.prototype.config = function (opts, cb) {
           (opts.github.user) ? opts.github.user.split(',') : [],
           (opts.github.org) ? opts.github.org.split(',') : [],
           _saveConfig);
-    }, opts.github.authUser, opts.github.authPass);
+    }, opts.github.authUser, opts.github.authPass, opts.github.useSsh);
   } else if (opts.gitorious) {
 
     console.log('Setting configuration file: %s, with Gitorious repositories', CONFIG_FILE);


### PR DESCRIPTION
Hey @basti1302 this option forces the use of the ssh url when creating the github config (the clone url seems to default to http). Let me know if you see any issues with this. 

I'll have one more option PR coming to give the possibility of removing repos from the config that aren't found in the config source (user, org, local, etc). Just as a heads up if you want to wait to review at once.