### PR TITLE
build(deps): remove dependency bluebird

### DIFF
--- a/lib/auth/github.js
+++ b/lib/auth/github.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const BluePromise = require('bluebird');
 const Github = require('@octokit/rest');
 const dotfile = require('dotfile')('repomanrc');
 const urlModule = require('url');
@@ -50,7 +49,7 @@ class GithubAuth {
 
   fetchAndStoreAuthToken(optionalTwoFactor) {
     const self = this;
-    return new BluePromise((s, f) => {
+    return new Promise((s, f) => {
       const headers = {};
       if (optionalTwoFactor) {
         headers['X-GitHub-OTP'] = optionalTwoFactor;
@@ -85,7 +84,7 @@ class GithubAuth {
   }
 
   readAuthToken() {
-    return new BluePromise((s, f) => {
+    return new Promise((s, f) => {
       dotfile.exists(yesno => {
         if (yesno) {
           dotfile.read((err, { githubAuthToken }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "async": "^2.6.4",
         "bagofcli": "^1.1.0",
         "bitbucket-api": "^0.1.0",
-        "bluebird": "^3.7.2",
         "cli-table": "^0.3.11",
         "colors": "^1.4.0",
         "dotfile": "0.0.2",
@@ -2756,7 +2755,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "async": "^2.6.4",
     "bagofcli": "^1.1.0",
     "bitbucket-api": "^0.1.0",
-    "bluebird": "^3.7.2",
     "cli-table": "^0.3.11",
     "colors": "^1.4.0",
     "dotfile": "0.0.2",

--- a/test/generator/github.js
+++ b/test/generator/github.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const BluePromise = require('bluebird');
 const sinon = require('sinon');
 
 const GithubAuth = require('../../lib/auth/github');
@@ -56,7 +55,7 @@ describe('github', () => {
     });
 
     it('should authenticate when username and password are not specified but auth token exists', done => {
-      const tokenPromise = BluePromise.resolve('tooken');
+      const tokenPromise = Promise.resolve('tooken');
       githubAuthMock.expects('readAuthToken').once().returns(tokenPromise);
       new GitHub(() => {});
       tokenPromise.then(() => {


### PR DESCRIPTION
Use native Promises instead. Bluebird is still an indirect dev dependency via jsdoc, but not a production dependency or a direct dependency anymore.